### PR TITLE
fix/Azure-1928-alteracao-linha11

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Antes de começar, certifique-se de ter as seguintes ferramentas instaladas em s
 
 -   [Node.js](https://nodejs.org/) (versão 14 ou superior)
 -   [NPM](https://www.npmjs.com/) ou [Yarn](https://yarnpkg.com/)
--   Uma conta no [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) para configurar um cluster do MongoDB - Composs
+-   Uma conta no [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) para configurar um cluster do MongoDB - Não vai ter nada de composs
 
 ## Instalação
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Antes de começar, certifique-se de ter as seguintes ferramentas instaladas em s
 
 -   [Node.js](https://nodejs.org/) (versão 14 ou superior)
 -   [NPM](https://www.npmjs.com/) ou [Yarn](https://yarnpkg.com/)
--   Uma conta no [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) para configurar um cluster do MongoDB
+-   Uma conta no [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) para configurar um cluster do MongoDB - Composs
 
 ## Instalação
 


### PR DESCRIPTION
Dado o item do Azure 1928 - o nome do MongoDB estava errado, consertei colocando o nome composs